### PR TITLE
Bump to 0.5.1

### DIFF
--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -12,7 +12,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 __all__ = [
     "NumPyBackend",
     "Backend",


### PR DESCRIPTION
Preparing a re-release with incremented `betterproto` dependency from https://github.com/pymc-devs/mcbackend/pull/95