### PR TITLE
Fix recognition of tuning stat in `.to_inferencedata()` method

### DIFF
--- a/mcbackend/__init__.py
+++ b/mcbackend/__init__.py
@@ -12,7 +12,7 @@ try:
 except ModuleNotFoundError:
     pass
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 __all__ = [
     "NumPyBackend",
     "Backend",

--- a/mcbackend/core.py
+++ b/mcbackend/core.py
@@ -238,7 +238,7 @@ class Run:
                     _log.warning(
                         "No 'tune' stat found. Assuming all iterations are posterior draws."
                     )
-                tune = numpy.repeat((chain_lengths[chain.cid],), False)
+                tune = numpy.full((chain_lengths[chain.cid],), False)
 
             # Split all variables draws into warmup/posterior
             for var in variables:


### PR DESCRIPTION
This fixes two bugs, one of which only got triggered by the first.

Since PyMC v5.7.0 the `"tune"` stat is sampler-wise, and named `"sampler_0__tune"` or similar.

However, the `.to_inferencedata()` implementation here was not updated, and kept looking for `"tune"`.
When this is not available, an all-false mask was supposed to be used, but since `np.repeat` was used, this was just an empty array, resulting in all draws getting sliced away all the time.

The change here is two-fold:
* :bug: Use `np.full` to create the mask if no tune stat was found.
* :bug: Look for stats named `"tune"` or ending with `"__tune"` to be compatible with PyMC before and after 5.7.0.
* 🔧 Added an `__all__` to hide non-public parts of the `.core` API.
* :up: Version incremented to 0.5.2